### PR TITLE
simple fix for broken links to icon example pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Please see the [Flowbite Svelte Icons documentation](https://flowbite-svelte-ico
 
 ## Icons
 
-- [Outline Icons](https://flowbite-svelte-icons.codewithshin.com/outline)
-- [Solid Icons](https://flowbite-svelte-icons.codewithshin.com/solid)
+- [Outline Icons](https://flowbite-svelte-icons.codewithshin.com/outline-icons)
+- [Solid Icons](https://flowbite-svelte-icons.codewithshin.com/solid-icons)
 
 ## Repo
 


### PR DESCRIPTION
It looks like some links changed on the codewithshin.com site.  Maybe an SEO optimization!

This is a simple fix, updating the paths in the README. 

Thanks for your efforts!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated URLs for outline and solid icons in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->